### PR TITLE
Replace obfy.hpp include guard

### DIFF
--- a/include/obfy/obfy.hpp
+++ b/include/obfy/obfy.hpp
@@ -19,8 +19,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  **/
 #pragma once
-#ifndef OBFY_INSTR_HPP
-#define OBFY_INSTR_HPP
+#ifndef __OBFY_HPP__
+#define __OBFY_HPP__
 
 #include <string>
 #include <typeinfo>
@@ -833,4 +833,4 @@ OBFY_DEFINE_EXTRA(2, extra_addition);
 
 } // namespace obfy
 
-#endif // OBFY_INSTR_HPP
+#endif // __OBFY_HPP__


### PR DESCRIPTION
## Summary
- rename include guard macro in obfy.hpp to __OBFY_HPP__
- allow safe repeated inclusion of the header

## Testing
- `g++ -std=c++14 -Iinclude /tmp/test_include.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68bbc9990c84832c9061a3bad892152e