### PR TITLE
Separate Boost tests from example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,12 @@ target_compile_features(obfy INTERFACE cxx_std_11)
 add_executable(example example/main.cpp)
 target_link_libraries(example PRIVATE obfy)
 
+enable_testing()
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+add_executable(obfy_tests tests/obfy_tests.cpp example/main.cpp)
+target_link_libraries(obfy_tests PRIVATE obfy Boost::unit_test_framework)
+target_compile_definitions(obfy_tests PRIVATE UNIT_TESTS)
+add_test(NAME obfy_tests COMMAND obfy_tests)
+
 install(TARGETS obfy)
 install(DIRECTORY include/ DESTINATION include)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,12 +1,5 @@
 #include <iostream>
-
-#if !defined( WIN32 )
-    #ifdef UNIT_TESTS
-        #define BOOST_TEST_MAIN
-        #define BOOST_TEST_DYN_LINK
-        #include <boost/test/auto_unit_test.hpp>
-    #endif
-#endif
+#include <stdint.h>
 
 #include <obfy/obfy.hpp>
 
@@ -353,67 +346,10 @@ ATest class_test(int& a)
     OBFY_END_CODE
 }
 
-#if !defined (WIN32) && defined (UNIT_TESTS)
-
-#include <stdint.h>
-
-BOOST_AUTO_TEST_OBFY_CASE(test_wrappers)
-{
-    BOOST_CHECK_EQUAL(numeric_wrapper_returner(), 42);
-    BOOST_CHECK_EQUAL(simple_variable_wrapper_min_eq(), -192);
-
-    BOOST_CHECK_EQUAL(variable_wrapper_returner(), 42);
-    BOOST_CHECK_EQUAL(variable_wrapper_operations(), 42);
-}
-
-BOOST_AUTO_TEST_OBFY_CASE(for_loops)
-{
-    BOOST_CHECK_EQUAL(for_loop_test(), 10);
-    BOOST_CHECK_EQUAL(for_loop_test_break(), 6);
-    BOOST_CHECK_EQUAL(for_loop_test_continue(), 9);
-}
-
-BOOST_AUTO_TEST_OBFY_CASE(while_loops)
-{
-    BOOST_CHECK_EQUAL(while_loop_test(), 10);
-    BOOST_CHECK_EQUAL(while_loop_test_break(), 6);
-    BOOST_CHECK_EQUAL(while_loop_test_continue(), 4);
-}
-
-BOOST_AUTO_TEST_OBFY_CASE(repeat_loops)
-{
-    BOOST_CHECK_EQUAL(repeat_loop_test(), 11);
-    BOOST_CHECK_EQUAL(repeat_loop_test_break(), 6);
-    BOOST_CHECK_EQUAL(repeat_loop_test_continue(), 4);
-}
-
-BOOST_AUTO_TEST_OBFY_CASE(case_test)
-{
-    BOOST_CHECK_EQUAL(case_tester(), 42);
-    BOOST_CHECK_EQUAL(case_tester_fallthrough(), 44);
-}
-
-BOOST_AUTO_TEST_OBFY_CASE(return_test)
-{
-    BOOST_CHECK_EQUAL(returner(), 42);
-    int a = 5;
-    ATest x = class_test(a);
-    BOOST_CHECK_EQUAL(a, 42);
-    BOOST_CHECK_EQUAL(x.x, 42);
-}
-
-BOOST_AUTO_TEST_OBFY_CASE(bignumber)
-{
-    int64_t bigNumber;
-    OBFY_V(bigNumber) = OBFY_N(1537232811123);
-    BOOST_CHECK_EQUAL(bigNumber,1537232811123);
-}
-
-#else
-#include <iostream>
+#ifndef UNIT_TESTS
 int main()
 {
-	std::cout
+    std::cout
         << "42:" << numeric_wrapper_returner() << std::endl
         << "-192:" << simple_variable_wrapper_min_eq() << std::endl
         << "42:" << variable_wrapper_returner() << std::endl
@@ -433,5 +369,4 @@ int main()
     OBFY_V(bigNumber) = OBFY_N(1537232811123);
     std::cout << "1537232811123:" << bigNumber << std::endl;
 }
-
 #endif

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -1,0 +1,80 @@
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/auto_unit_test.hpp>
+#define BOOST_AUTO_TEST_OBFY_CASE BOOST_AUTO_TEST_CASE
+
+#include <obfy/obfy.hpp>
+#include <stdint.h>
+
+int numeric_wrapper_returner();
+int simple_variable_wrapper_min_eq();
+int variable_wrapper_returner();
+int variable_wrapper_operations();
+int for_loop_test();
+int for_loop_test_break();
+int for_loop_test_continue();
+int while_loop_test();
+int while_loop_test_break();
+int while_loop_test_continue();
+int repeat_loop_test();
+int repeat_loop_test_break();
+int repeat_loop_test_continue();
+int case_tester();
+int case_tester_fallthrough();
+int returner();
+
+struct ATest { int x = 42; };
+ATest class_test(int& a);
+
+BOOST_AUTO_TEST_OBFY_CASE(test_wrappers)
+{
+    BOOST_CHECK_EQUAL(numeric_wrapper_returner(), 42);
+    BOOST_CHECK_EQUAL(simple_variable_wrapper_min_eq(), -192);
+
+    BOOST_CHECK_EQUAL(variable_wrapper_returner(), 42);
+    BOOST_CHECK_EQUAL(variable_wrapper_operations(), 42);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(for_loops)
+{
+    BOOST_CHECK_EQUAL(for_loop_test(), 10);
+    BOOST_CHECK_EQUAL(for_loop_test_break(), 6);
+    BOOST_CHECK_EQUAL(for_loop_test_continue(), 9);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(while_loops)
+{
+    BOOST_CHECK_EQUAL(while_loop_test(), 10);
+    BOOST_CHECK_EQUAL(while_loop_test_break(), 6);
+    BOOST_CHECK_EQUAL(while_loop_test_continue(), 4);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(repeat_loops)
+{
+    BOOST_CHECK_EQUAL(repeat_loop_test(), 11);
+    BOOST_CHECK_EQUAL(repeat_loop_test_break(), 6);
+    BOOST_CHECK_EQUAL(repeat_loop_test_continue(), 4);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(case_test)
+{
+    BOOST_CHECK_EQUAL(case_tester(), 42);
+    BOOST_CHECK_EQUAL(case_tester_fallthrough(), 44);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(return_test)
+{
+    BOOST_CHECK_EQUAL(returner(), 42);
+    int a = 5;
+    ATest x = class_test(a);
+    BOOST_CHECK_EQUAL(a, 42);
+    BOOST_CHECK_EQUAL(x.x, 42);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(bignumber)
+{
+    int64_t bigNumber;
+    OBFY_V(bigNumber) = OBFY_N(1537232811123);
+    BOOST_CHECK_EQUAL(bigNumber,1537232811123);
+}
+


### PR DESCRIPTION
## Summary
- move Boost test cases from `example/main.cpp` into `tests/obfy_tests.cpp`
- add standalone CMake target to build and run tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bbcb1f23ac832c9ba72d3e5edd0807