### PR TITLE
feat(seed): diversify literal keys with TU salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,24 @@ Or in CMake:
 add_compile_definitions(OBFY_SEED=123456)
 ```
 
+### Translation-unit salt
+
+Each translation unit gets its own salt by hashing the file name. Override the
+label used for hashing with `OBFY_FILE_FOR_HASH` to avoid leaking full paths or
+to tag files in unity builds:
+
+```bash
+g++ ... -DOBFY_FILE_FOR_HASH="\"module-a\""
+```
+
+```cmake
+add_compile_definitions(OBFY_FILE_FOR_HASH="\"module-a\"")
+```
+
+You may also define `OBFY_TU_SALT` directly to supply a custom salt. The
+resulting value is mixed with `OBFY_SEED`, `__LINE__` and `__COUNTER__` by
+`OBFY_LOCAL_KEY()` to generate a unique key for each literal.
+
 ### Debugging with the framework
 
 Like every developer who has been there, we know that debugging complex and highly templated c++ code sometimes can be a nightmare. In order to avoid this nightmare while using the framework we decided to implement a debugging mode.


### PR DESCRIPTION
## Summary
- add mix64/fnv1a64 helpers and TU salt constants
- generate per-literal keys by mixing global seed, TU salt, line and counter
- document TU salt and local key macros

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bcd402ad98832c86bbed5567ab21a0