### PR TITLE
docs: document runtime tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,24 @@ Or in CMake:
 add_compile_definitions(OBFY_SEED=123456)
 ```
 
+At runtime obfy applies an extra tweak by mixing the current process ID,
+the address of a stack variable and the current time through `mix64`.
+This per-run value is combined with `OBFY_SEED`, making static analysis harder.
+Define `OBFY_DISABLE_RUNTIME_TWEAK` to turn it off:
+
+```bash
+g++ ...                        # runtime tweak enabled
+g++ ... -DOBFY_DISABLE_RUNTIME_TWEAK  # disabled
+```
+
+Or in CMake:
+
+```cmake
+add_compile_definitions(OBFY_DISABLE_RUNTIME_TWEAK)
+```
+
+Disabling the tweak makes keys deterministic and simplifies static analysis.
+
 ### Translation-unit salt
 
 Each translation unit gets its own salt by hashing the file name. Override the


### PR DESCRIPTION
## Summary
- describe runtime tweak mixing PID, address and time
- show how to disable runtime tweak via `OBFY_DISABLE_RUNTIME_TWEAK`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bcdd694668832cb3cee5d1068afdb9