### PR TITLE
test: verify runtime tweak decoding

### DIFF
--- a/include/obfy/obfy.hpp
+++ b/include/obfy/obfy.hpp
@@ -99,8 +99,14 @@ namespace detail {
     }
 #endif
 
+    inline uint64_t& runtime_tweak_counter() {
+        static uint64_t counter = 0;
+        return counter;
+    }
+
 #ifndef OBFY_DISABLE_RUNTIME_TWEAK
     inline uint64_t runtime_tweak() {
+        ++runtime_tweak_counter();
         int _obfy_dummy = 0;
 #if defined(_WIN32)
         uint64_t pid = static_cast<uint64_t>(GetCurrentProcessId());

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -71,6 +71,14 @@ BOOST_AUTO_TEST_OBFY_CASE(return_test)
     BOOST_CHECK_EQUAL(x.x, 42);
 }
 
+BOOST_AUTO_TEST_OBFY_CASE(runtime_tweak_test)
+{
+    ::obfy::detail::runtime_tweak_counter() = 0;
+    auto value = OBFY_N(42);
+    BOOST_CHECK_EQUAL(value, 42);
+    BOOST_CHECK(::obfy::detail::runtime_tweak_counter() > 0);
+}
+
 BOOST_AUTO_TEST_OBFY_CASE(bignumber)
 {
     int64_t bigNumber;


### PR DESCRIPTION
## Summary
- track calls to runtime_tweak
- add unit test for OBFY_N verifying decoded constant and tweak execution

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bcde449f18832c8023b9906d7322a4