### PR TITLE
feat: add floating point helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,8 @@ This brings us back to the swampy area of C++ and macros. There are several voic
 
 And last, but not least, the numeric value wrappers do not work with floating point numbers. This is due to the fact that extensive binary operations are used on the number to obfuscate its value and this would be impossible to accomplish with floating point values.
 
+For occasional floating point constants you can assemble them from integers with `OBFY_RATIO_D` or `OBFY_RATIO_F`, e.g. `double pi = OBFY_RATIO_D(314, 100);`. These macros divide the obfuscated numerator and denominator at runtime. If an exact IEEE-754 bit pattern is required, store the bits as an integer and recover the value via `OBFY_BIT_CAST`.
+
 # Some requirements
 
 The code is written also with "older" compilers in mind, so not all the latest and greatest features of C++14 and 17 are being included. CLang version 3.4.1 happily compiles the source code, so does g++ 4.8.2. Visual Studio 2015 is also compiling the code.

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -78,3 +78,28 @@ BOOST_AUTO_TEST_OBFY_CASE(bignumber)
     BOOST_CHECK_EQUAL(bigNumber,1537232811123);
 }
 
+BOOST_AUTO_TEST_OBFY_CASE(ratio_and_bitcast)
+{
+    double d = OBFY_RATIO_D(314, 100);
+    float f = OBFY_RATIO_F(157, 50);
+    BOOST_CHECK(d > 3.13 && d < 3.15);
+    BOOST_CHECK(f > 3.13f && f < 3.15f);
+
+    const uint32_t b32 = 0x4048F5C3u;
+    const uint64_t b64 = 0x40091EB851EB851FULL;
+    float rf = obfy::obfy_bit_cast<float>(b32);
+    double rd = obfy::obfy_bit_cast<double>(b64);
+    BOOST_CHECK_EQUAL(obfy::obfy_bit_cast<uint32_t>(rf), b32);
+    BOOST_CHECK_EQUAL(obfy::obfy_bit_cast<uint64_t>(rd), b64);
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(bit_cast_macro)
+{
+    const uint32_t b32 = 0x4048F5C3u;
+    const uint64_t b64 = 0x40091EB851EB851FULL;
+    float rf = OBFY_BIT_CAST(float, b32);
+    double rd = OBFY_BIT_CAST(double, b64);
+    BOOST_CHECK_EQUAL(OBFY_BIT_CAST(uint32_t, rf), b32);
+    BOOST_CHECK_EQUAL(OBFY_BIT_CAST(uint64_t, rd), b64);
+}
+


### PR DESCRIPTION
## Summary
- add `obfy_bit_cast` utility for safe bit-wise casts
- expose `OBFY_BIT_CAST` macro wrapper
- support floating point ratios with `OBFY_RATIO_D` and `OBFY_RATIO_F`
- document and test new helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bcebca72d0832c824b1b25af38ba0d