### PR TITLE
feat: obfuscate floating-point variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ void log_message() {
 
 #### Value and numerical wrappers
 
-To achieve an extra layer of obfuscation, the integral numerical values can be wrapped in the macro `OBFY_N()` and all integral numeric variables (`int`, `long`, ...) can be wrapped in the macro `OBFY_V()` to provide an extra layer of obfuscation for doing the calculation operations. The argument to `OBFY_N` must be a constant expression of an integral or enumeration type. The `OBFY_V()` value wrapper also can wrap individual array elements(`x[2]`), but not arrays (`x`) and also cannot wrap class instantiation values due to the fact that the macro expands to a reference holder object.
+To achieve an extra layer of obfuscation, the integral numerical values can be wrapped in the macro `OBFY_N()` and numeric variables (`int`, `long`, `float`, `double`, ...) can be wrapped in the macro `OBFY_V()` to provide an extra layer of obfuscation for doing the calculation operations. The argument to `OBFY_N` must be a constant expression of an integral or enumeration type. The `OBFY_V()` value wrapper also can wrap individual array elements(`x[2]`), but not arrays (`x`) and also cannot wrap class instantiation values due to the fact that the macro expands to a reference holder object.
 
 The implementation of the wrappers uses the link time random number generator provided by [Andrivet] and the values are obfuscated by performing various operations to hide the original value.
 
@@ -296,9 +296,11 @@ And here is an example for using the value and variable wrappers:
 ```cpp
 int a, b = OBFY_N(6);
 OBFY_V(a) = OBFY_N(1);
+float f;
+OBFY_V(f) = 3.14f;
 ```
 
-After executing the statement above, the value of `a` will be 1.
+After executing the statement above, the value of `a` will be 1 and `f` will be `3.14f`.
 
 The value wrappers implement a limited set of operations which you can use to change the value of the wrapped variable. These are the compound assignment operators: `+=`, `-=`, `*=`, `/=`, `%=`, `<<=`, `>>=`, `&=`, `|=`, `^=` and the post/pre-increment operations `--` and `++`. All of the binary operators `+`, `-`, `*`, `/`, `%`, `&`, `|`, `<<`, `>>` are also implemented so you can write `OBFY_V(a) + OBFY_N(1)` or `OBFY_V(a) - OBFY_V(b)`.
 
@@ -1205,9 +1207,9 @@ Those who dislike the usage of CAPITAL letters in code may find the framework to
 
 This brings us back to the swampy area of C++ and macros. There are several voices whispering loudly that macros have nothing to do in a C++ code, and there are several voices echoing back that macros if wisely used can help C++ code as well as good old style C. I personally have nothing against the wise use of macros, indeed they came to be very helpful while developing this framework.
 
-And last, but not least, the numeric value wrappers do not work with floating point numbers. This is due to the fact that extensive binary operations are used on the number to obfuscate its value and this would be impossible to accomplish with floating point values.
+Numeric value wrappers also work with floating point variables. `OBFY_V` can wrap `float` and `double` values by obfuscating their underlying byte representation. The `OBFY_N` macro remains limited to integral and enumeration constants.
 
-For occasional floating point constants you can assemble them from integers with `OBFY_RATIO_D` or `OBFY_RATIO_F`, e.g. `double pi = OBFY_RATIO_D(314, 100);`. These macros divide the obfuscated numerator and denominator at runtime. If an exact IEEE-754 bit pattern is required, store the bits as an integer and recover the value via `OBFY_BIT_CAST`.
+For floating point constants you can assemble them from integers with `OBFY_RATIO_D` or `OBFY_RATIO_F`, e.g. `double pi = OBFY_RATIO_D(314, 100);`. These macros divide the obfuscated numerator and denominator at runtime. If an exact IEEE-754 bit pattern is required, store the bits as an integer and recover the value via `OBFY_BIT_CAST`.
 
 # Some requirements
 

--- a/include/obfy/obfy.hpp
+++ b/include/obfy/obfy.hpp
@@ -244,8 +244,6 @@ public:
 
     /* Comparison */
     bool operator==(const T& ov) const {
-        static_assert(!std::is_floating_point<T>::value,
-                      "refholder does not support floating point types");
         T tmp = v;
         typedef std::integral_constant<bool,
             std::is_integral<T>::value || std::is_enum<T>::value> is_int;
@@ -788,6 +786,52 @@ class extra_xor <const T> final : public basic_extra
 {
 public:
     extra_xor(const T&) {}
+};
+
+template <>
+class extra_xor<float> final : public basic_extra
+{
+public:
+    extra_xor(float& a) : v(a)
+    {
+        uint32_t lv = static_cast<uint32_t>(MetaRandom<__COUNTER__, 4096>::value);
+        uint32_t tmp = obfy_bit_cast<uint32_t>(static_cast<float>(v));
+        tmp ^= lv;
+        v = obfy_bit_cast<float>(tmp);
+    }
+    virtual ~extra_xor()
+    {
+        uint32_t lv = static_cast<uint32_t>(MetaRandom<__COUNTER__ - 1, 4096>::value);
+        uint32_t tmp = obfy_bit_cast<uint32_t>(static_cast<float>(v));
+        tmp ^= lv;
+        v = obfy_bit_cast<float>(tmp);
+    }
+
+private:
+    volatile float& v;
+};
+
+template <>
+class extra_xor<double> final : public basic_extra
+{
+public:
+    extra_xor(double& a) : v(a)
+    {
+        uint64_t lv = static_cast<uint64_t>(MetaRandom<__COUNTER__, 4096>::value);
+        uint64_t tmp = obfy_bit_cast<uint64_t>(static_cast<double>(v));
+        tmp ^= lv;
+        v = obfy_bit_cast<double>(tmp);
+    }
+    virtual ~extra_xor()
+    {
+        uint64_t lv = static_cast<uint64_t>(MetaRandom<__COUNTER__ - 1, 4096>::value);
+        uint64_t tmp = obfy_bit_cast<uint64_t>(static_cast<double>(v));
+        tmp ^= lv;
+        v = obfy_bit_cast<double>(tmp);
+    }
+
+private:
+    volatile double& v;
 };
 
 template <class T>

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -103,3 +103,16 @@ BOOST_AUTO_TEST_OBFY_CASE(bit_cast_macro)
     BOOST_CHECK_EQUAL(OBFY_BIT_CAST(uint64_t, rd), b64);
 }
 
+BOOST_AUTO_TEST_OBFY_CASE(float_variable_wrapper)
+{
+    float f = 0.0f;
+    OBFY_V(f) = 1.5f;
+    OBFY_V(f) += 2.25f;
+    BOOST_CHECK_CLOSE(static_cast<double>(f), 3.75, 0.001);
+
+    double d = 0.0;
+    OBFY_V(d) = 2.0;
+    OBFY_V(d) *= 1.5;
+    BOOST_CHECK_CLOSE(d, 3.0, 0.001);
+}
+


### PR DESCRIPTION
## Summary
- extend `refholder` and extra XOR operation to wrap `float` and `double`
- test obfuscation for floating-point variables
- document floating-point support in README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf4242f98832c90c21033e9c27c64