### PR TITLE
feat: add string literal obfuscation macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,6 +1209,12 @@ This brings us back to the swampy area of C++ and macros. There are several voic
 
 Numeric value wrappers also work with floating point variables. `OBFY_V` can wrap `float` and `double` values by obfuscating their underlying byte representation. The `OBFY_N` macro remains limited to integral and enumeration constants.
 
+String literals can be protected with `OBFY_STR`. The characters are encoded at compile time using a blend of XOR and arithmetic transformations and decoded on demand at runtime.
+
+```cpp
+const char* hello = OBFY_STR("hello world");
+```
+
 For floating point constants you can assemble them from integers with `OBFY_RATIO_D` or `OBFY_RATIO_F`, e.g. `double pi = OBFY_RATIO_D(314, 100);`. These macros divide the obfuscated numerator and denominator at runtime. If an exact IEEE-754 bit pattern is required, store the bits as an integer and recover the value via `OBFY_BIT_CAST`.
 
 # Some requirements

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -369,5 +369,6 @@ int main()
     int64_t bigNumber;
     OBFY_V(bigNumber) = OBFY_N(1537232811123);
     std::cout << "1537232811123:" << bigNumber << std::endl;
+    std::cout << OBFY_STR("hello obfy") << std::endl;
 }
 #endif

--- a/include/obfy/obfy.hpp
+++ b/include/obfy/obfy.hpp
@@ -1025,4 +1025,6 @@ OBFY_DEFINE_EXTRA(2, extra_addition);
 
 } // namespace obfy
 
+#include <obfy/obfy_str.hpp>
+
 #endif // __OBFY_HPP__

--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -1,0 +1,62 @@
+#ifndef OBFY_STR_HPP
+#define OBFY_STR_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+namespace obfy {
+namespace detail {
+
+    template<std::size_t... I>
+    struct index_sequence { };
+
+    template<std::size_t N, std::size_t... I>
+    struct make_index_sequence_impl : make_index_sequence_impl<N-1, N-1, I...> { };
+
+    template<std::size_t... I>
+    struct make_index_sequence_impl<0, I...> { using type = index_sequence<I...>; };
+
+    template<std::size_t N>
+    using make_index_sequence = typename make_index_sequence_impl<N>::type;
+
+    template<char K1, char K2, char K3, typename Seq>
+    struct obf_string;
+
+    template<char K1, char K2, char K3, std::size_t... I>
+    struct obf_string<K1, K2, K3, index_sequence<I...>> {
+        unsigned char data[sizeof...(I) + 1];
+        constexpr obf_string(const char* str)
+            : data{ encode(str[I], I)..., 0 } {}
+        const char* decrypt() {
+            for (std::size_t i = 0; i < sizeof...(I); ++i) {
+                data[i] = decode(data[i], i);
+            }
+            return reinterpret_cast<const char*>(data);
+        }
+        static constexpr unsigned char encode(char c, std::size_t i) {
+            return static_cast<unsigned char>(
+                (( (static_cast<unsigned char>(c) ^ static_cast<unsigned char>(K1))
+                 + static_cast<unsigned char>(K2))
+                 ^ static_cast<unsigned char>(static_cast<unsigned char>(K3) + static_cast<unsigned char>(i))));
+        }
+        static constexpr unsigned char decode(unsigned char c, std::size_t i) {
+            return static_cast<unsigned char>(
+                (( (c ^ static_cast<unsigned char>(static_cast<unsigned char>(K3) + static_cast<unsigned char>(i)))
+                 - static_cast<unsigned char>(K2))
+                 ^ static_cast<unsigned char>(K1)));
+        }
+    };
+
+} // namespace detail
+} // namespace obfy
+
+#define OBFY_DEF_STR(s) \
+    ::obfy::detail::obf_string< \
+        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
+        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
+        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
+        ::obfy::detail::make_index_sequence<sizeof(s) - 1>>(s)
+
+#define OBFY_STR(s) ([](){ static auto _obfy_str = OBFY_DEF_STR(s); return _obfy_str.decrypt(); }())
+
+#endif // OBFY_STR_HPP

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -103,6 +103,12 @@ BOOST_AUTO_TEST_OBFY_CASE(bit_cast_macro)
     BOOST_CHECK_EQUAL(OBFY_BIT_CAST(uint64_t, rd), b64);
 }
 
+BOOST_AUTO_TEST_OBFY_CASE(string_literal)
+{
+    BOOST_CHECK_EQUAL(std::string(OBFY_STR("test")), "test");
+    BOOST_CHECK_EQUAL(std::string(OBFY_STR("")), "");
+}
+
 BOOST_AUTO_TEST_OBFY_CASE(float_variable_wrapper)
 {
     float f = 0.0f;


### PR DESCRIPTION
## Summary
- add `OBFY_STR` macro and helpers for compile-time encoded strings
- demonstrate `OBFY_STR` usage in example
- document string obfuscation and test it

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf91c98b8832cb279677d4afd5957