### PR TITLE
feat(strings): ensure thread-safe decode

### DIFF
--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -54,8 +54,8 @@ namespace detail {
         static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value), \
         static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value), \
         static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value), \
-        ::obfy::detail::make_index_sequence<sizeof(s) - 1>>(s)
+        ::obfy::detail::make_index_sequence<sizeof(s) - 1>>
 
-#define OBFY_STR(s) ([](){ static auto _obfy_str = OBFY_DEF_STR(s); return _obfy_str.decrypt(); }())
+#define OBFY_STR(s) ([](){ static OBFY_DEF_STR(s) _obfy_str{ s }; return _obfy_str.decrypt(); }())
 
 #endif // __OBFY_STR_HPP__

--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 
 namespace obfy {
 namespace detail {
@@ -19,31 +20,29 @@ namespace detail {
     template<std::size_t N>
     using make_index_sequence = typename make_index_sequence_impl<N>::type;
 
-    template<char K1, char K2, char K3, typename Seq>
+    template<unsigned char K1, unsigned char K2, unsigned char K3, typename Seq>
     struct obf_string;
 
-    template<char K1, char K2, char K3, std::size_t... I>
+    template<unsigned char K1, unsigned char K2, unsigned char K3, std::size_t... I>
     struct obf_string<K1, K2, K3, index_sequence<I...>> {
         unsigned char data[sizeof...(I) + 1];
-        constexpr obf_string(const char* str)
-            : data{ encode(str[I], I)..., 0 } {}
+        mutable std::once_flag once_;
+        template<std::size_t N>
+        constexpr obf_string(const char (&s)[N])
+            : data{ encode(s[I], I)..., 0 } {}
         const char* decrypt() {
-            for (std::size_t i = 0; i < sizeof...(I); ++i) {
-                data[i] = decode(data[i], i);
-            }
+            std::call_once(once_, [&]{
+                for (std::size_t i = 0; i < sizeof...(I); ++i)
+                    data[i] = decode(data[i], i);
+            });
             return reinterpret_cast<const char*>(data);
         }
         static constexpr unsigned char encode(char c, std::size_t i) {
-            return static_cast<unsigned char>(
-                (( (static_cast<unsigned char>(c) ^ static_cast<unsigned char>(K1))
-                 + static_cast<unsigned char>(K2))
-                 ^ static_cast<unsigned char>(static_cast<unsigned char>(K3) + static_cast<unsigned char>(i))));
+            unsigned char uc = static_cast<unsigned char>(c);
+            return static_cast<unsigned char>(((uc ^ K1) + K2) ^ static_cast<unsigned char>(K3 + static_cast<unsigned char>(i)));
         }
         static constexpr unsigned char decode(unsigned char c, std::size_t i) {
-            return static_cast<unsigned char>(
-                (( (c ^ static_cast<unsigned char>(static_cast<unsigned char>(K3) + static_cast<unsigned char>(i)))
-                 - static_cast<unsigned char>(K2))
-                 ^ static_cast<unsigned char>(K1)));
+            return static_cast<unsigned char>(((c ^ static_cast<unsigned char>(K3 + static_cast<unsigned char>(i))) - K2) ^ K1);
         }
     };
 
@@ -52,9 +51,9 @@ namespace detail {
 
 #define OBFY_DEF_STR(s) \
     ::obfy::detail::obf_string< \
-        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
-        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
-        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value), \
         ::obfy::detail::make_index_sequence<sizeof(s) - 1>>(s)
 
 #define OBFY_STR(s) ([](){ static auto _obfy_str = OBFY_DEF_STR(s); return _obfy_str.decrypt(); }())


### PR DESCRIPTION
## Summary
- use unsigned template parameters and widen key space
- make first use decoding thread-safe with std::once_flag

## Testing
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68bcfd875e70832c92ef0e16c1caab3c