### PR TITLE
feat(strings): add secure and wide-string variants

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -370,5 +370,7 @@ int main()
     OBFY_V(bigNumber) = OBFY_N(1537232811123);
     std::cout << "1537232811123:" << bigNumber << std::endl;
     std::cout << OBFY_STR("hello obfy") << std::endl;
+    std::cout << OBFY_STR_ONCE("temp secret") << std::endl;
+    std::wcout << OBFY_WSTR(L"wide obfy") << std::endl;
 }
 #endif

--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -3,6 +3,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
+#include <string>
 
 namespace obfy {
 namespace detail {
@@ -19,44 +21,71 @@ namespace detail {
     template<std::size_t N>
     using make_index_sequence = typename make_index_sequence_impl<N>::type;
 
-    template<char K1, char K2, char K3, typename Seq>
-    struct obf_string;
+    template<typename Char, unsigned char K1, unsigned char K2, unsigned char K3, typename Seq>
+    struct obf_string_impl;
 
-    template<char K1, char K2, char K3, std::size_t... I>
-    struct obf_string<K1, K2, K3, index_sequence<I...>> {
-        unsigned char data[sizeof...(I) + 1];
-        constexpr obf_string(const char* str)
-            : data{ encode(str[I], I)..., 0 } {}
-        const char* decrypt() {
-            for (std::size_t i = 0; i < sizeof...(I); ++i) {
-                data[i] = decode(data[i], i);
-            }
-            return reinterpret_cast<const char*>(data);
+    template<typename Char, unsigned char K1, unsigned char K2, unsigned char K3, std::size_t... I>
+    struct obf_string_impl<Char, K1, K2, K3, index_sequence<I...>> {
+        alignas(Char) unsigned char data[sizeof...(I) + sizeof(Char)];
+        mutable std::once_flag once_;
+        template<std::size_t N>
+        constexpr obf_string_impl(const Char (&s)[N])
+            : data{ encode(reinterpret_cast<const unsigned char*>(s)[I], I)... } {}
+        const Char* decrypt() {
+            std::call_once(once_, [&]{
+                for (std::size_t i = 0; i < sizeof...(I); ++i)
+                    data[i] = decode(data[i], i);
+            });
+            return reinterpret_cast<const Char*>(data);
         }
-        static constexpr unsigned char encode(char c, std::size_t i) {
-            return static_cast<unsigned char>(
-                (( (static_cast<unsigned char>(c) ^ static_cast<unsigned char>(K1))
-                 + static_cast<unsigned char>(K2))
-                 ^ static_cast<unsigned char>(static_cast<unsigned char>(K3) + static_cast<unsigned char>(i))));
+        struct tmp_string {
+            std::basic_string<Char> str;
+            ~tmp_string() { for (std::size_t i = 0; i < str.size(); ++i) str[i] = Char(); }
+            operator const std::basic_string<Char>&() const { return str; }
+            operator const Char*() const { return str.c_str(); }
+        };
+        tmp_string decrypt_once() const {
+            tmp_string tmp;
+            tmp.str.resize(sizeof...(I) / sizeof(Char));
+            unsigned char* raw = reinterpret_cast<unsigned char*>(&tmp.str[0]);
+            for (std::size_t i = 0; i < sizeof...(I); ++i)
+                raw[i] = decode(data[i], i);
+            return tmp;
+        }
+        static constexpr unsigned char encode(unsigned char c, std::size_t i) {
+            return static_cast<unsigned char>(((c ^ K1) + K2) ^ static_cast<unsigned char>(K3 + static_cast<unsigned char>(i)));
         }
         static constexpr unsigned char decode(unsigned char c, std::size_t i) {
-            return static_cast<unsigned char>(
-                (( (c ^ static_cast<unsigned char>(static_cast<unsigned char>(K3) + static_cast<unsigned char>(i)))
-                 - static_cast<unsigned char>(K2))
-                 ^ static_cast<unsigned char>(K1)));
+            return static_cast<unsigned char>(((c ^ static_cast<unsigned char>(K3 + static_cast<unsigned char>(i))) - K2) ^ K1);
         }
     };
+
+    template<unsigned char K1, unsigned char K2, unsigned char K3, std::size_t... I>
+    using obf_string = obf_string_impl<char, K1, K2, K3, index_sequence<I...>>;
+
+    template<unsigned char K1, unsigned char K2, unsigned char K3, std::size_t... I>
+    using obf_wstring = obf_string_impl<wchar_t, K1, K2, K3, index_sequence<I...>>;
 
 } // namespace detail
 } // namespace obfy
 
-#define OBFY_DEF_STR(s) \
-    ::obfy::detail::obf_string< \
-        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
-        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
-        static_cast<char>(::obfy::MetaRandom<__COUNTER__, 0x7F>::value + 1), \
-        ::obfy::detail::make_index_sequence<sizeof(s) - 1>>(s)
+#ifndef OBFY_TU_SALT
+#  define OBFY_TU_SALT 0ull
+#endif
 
-#define OBFY_STR(s) ([](){ static auto _obfy_str = OBFY_DEF_STR(s); return _obfy_str.decrypt(); }())
+#define OBFY_DEF_STR_T(Char, s) \
+    ::obfy::detail::obf_string_impl<Char, \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 0) & 0xFF)), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 8) & 0xFF)), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 16) & 0xFF)), \
+        ::obfy::detail::make_index_sequence<sizeof(s) - sizeof(Char)>>
+
+#define OBFY_DEF_STR(s) OBFY_DEF_STR_T(char, s)
+#define OBFY_DEF_WSTR(s) OBFY_DEF_STR_T(wchar_t, s)
+
+#define OBFY_STR(s) ([](){ static OBFY_DEF_STR(s) _obfy_str{ s }; return _obfy_str.decrypt(); }())
+#define OBFY_WSTR(s) ([](){ static OBFY_DEF_WSTR(s) _obfy_wstr{ s }; return _obfy_wstr.decrypt(); }())
+#define OBFY_STR_ONCE(s) ([](){ OBFY_DEF_STR(s) _obfy_str{ s }; return _obfy_str.decrypt_once(); }())
+#define OBFY_WSTR_ONCE(s) ([](){ OBFY_DEF_WSTR(s) _obfy_wstr{ s }; return _obfy_wstr.decrypt_once(); }())
 
 #endif // __OBFY_STR_HPP__

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -107,6 +107,8 @@ BOOST_AUTO_TEST_OBFY_CASE(string_literal)
 {
     BOOST_CHECK_EQUAL(std::string(OBFY_STR("test")), "test");
     BOOST_CHECK_EQUAL(std::string(OBFY_STR("")), "");
+    BOOST_CHECK_EQUAL(std::string(OBFY_STR_ONCE("test once")), "test once");
+    BOOST_CHECK_EQUAL(std::wstring(OBFY_WSTR(L"wide")), L"wide");
 }
 
 BOOST_AUTO_TEST_OBFY_CASE(float_variable_wrapper)


### PR DESCRIPTION
## Summary
- add RAII-based `OBFY_STR_ONCE` and `OBFY_WSTR` helpers
- mix per-string keys with translation-unit salt for diversification
- exercise new macros in example and tests

## Testing
- `cmake -S . -B build -DCMAKE_CXX_STANDARD=11` *(fails: Could NOT find Boost)*
- `apt-get install -y libboost-test-dev` *(fails: Waiting for headers)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfd875e70832c92ef0e16c1caab3c