### PR TITLE
fix(obfy_str): include obfy.hpp internally

### DIFF
--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -6,6 +6,8 @@
 #include <mutex>
 #include <string>
 
+#include <obfy/obfy.hpp>
+
 namespace obfy {
 namespace detail {
 


### PR DESCRIPTION
## Summary
- include `<obfy/obfy.hpp>` inside `obfy_str.hpp` so the string obfuscation helpers are self-contained

## Testing
- `g++ -std=c++11 -Iinclude -c /tmp/test_tu.cpp -o /tmp/test_tu.o`
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bd0ce83714832c9131d1a28cea2185