### PR TITLE
fix(windows): avoid min/max macro pollution

### DIFF
--- a/include/obfy/obfy.hpp
+++ b/include/obfy/obfy.hpp
@@ -34,6 +34,9 @@
 #include <ctime>
 #include <cstring>
 #if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
## Summary
- prevent `windows.h` from defining `min`/`max` macros by defining `NOMINMAX`

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR unit_test_framework))*


------
https://chatgpt.com/codex/tasks/task_e_68bd13190d70832cb056fe6e49351379