### PR TITLE
Run tests with OBFY_DEBUG enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if(OBFY_BUILD_TESTS)
     target_link_libraries(obfy_tests PRIVATE obfy Boost::unit_test_framework)
     target_compile_definitions(obfy_tests PRIVATE UNIT_TESTS)
     add_test(NAME obfy_tests COMMAND obfy_tests)
+
+    add_executable(obfy_tests_debug tests/obfy_tests.cpp example/main.cpp)
+    target_link_libraries(obfy_tests_debug PRIVATE obfy Boost::unit_test_framework)
+    target_compile_definitions(obfy_tests_debug PRIVATE UNIT_TESTS OBFY_DEBUG)
+    add_test(NAME obfy_tests_debug COMMAND obfy_tests_debug)
 endif()
 
 install(TARGETS obfy)

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -1,6 +1,10 @@
-#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#ifdef OBFY_DEBUG
+#define BOOST_TEST_MODULE obfy_debug_tests
+#else
+#define BOOST_TEST_MODULE obfy_tests
+#endif
+#include <boost/test/unit_test.hpp>
 #define BOOST_AUTO_TEST_OBFY_CASE BOOST_AUTO_TEST_CASE
 
 #include <obfy/obfy.hpp>


### PR DESCRIPTION
## Summary
- build obfy tests both with and without `OBFY_DEBUG`
- enable running the new debug test target via CTest when tests are built

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bd0f078294832c928c0e239537357b