### PR TITLE
feat(call): add optional obfuscated call wrapper

### DIFF
--- a/include/obfy/obfy_call.hpp
+++ b/include/obfy/obfy_call.hpp
@@ -1,0 +1,89 @@
+#ifndef __OBFY_CALL_HPP__
+#define __OBFY_CALL_HPP__
+
+#include <obfy/obfy.hpp>
+
+#ifdef OBFY_ENABLE_FSM_CALL
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+#endif
+
+#if defined(_MSC_VER)
+#  define OBFY_NOINLINE __declspec(noinline)
+#else
+#  define OBFY_NOINLINE __attribute__((noinline))
+#endif
+
+namespace obfy {
+
+#ifdef OBFY_ENABLE_FSM_CALL
+
+#ifndef OBFY_CALL_STEPS
+#define OBFY_CALL_STEPS 32u
+#endif
+
+namespace detail {
+    inline uint32_t lcg(uint32_t x) { return x * 1664525u + 1013904223u; }
+}
+
+template<class F>
+struct obf_addr {
+    uintptr_t v;
+    uintptr_t k;
+    explicit constexpr obf_addr(F f, uintptr_t salt)
+        : v(reinterpret_cast<uintptr_t>(f) ^ salt), k(salt) {}
+    inline F get() const { return reinterpret_cast<F>(v ^ k); }
+};
+
+template<typename R, typename F, typename... Args>
+OBFY_NOINLINE typename std::enable_if<!std::is_void<R>::value, R>::type
+obfy_call_impl(F f, Args&&... args) {
+    const uintptr_t salt = detail::mix64(OBFY_LOCAL_KEY() ^ detail::runtime_tweak_seed());
+    obf_addr<F> oa(f, salt);
+    volatile uint32_t s = static_cast<uint32_t>(salt);
+    const uint32_t fire = s % OBFY_CALL_STEPS;
+    R ret{};
+    for (uint32_t i = 0; i < OBFY_CALL_STEPS; ++i) {
+        s = detail::lcg(s) ^ static_cast<uint32_t>(i * 2654435761u);
+        if (i == fire) {
+            F g = oa.get();
+            ret = g(std::forward<Args>(args)...);
+        } else {
+            s ^= (s >> 13);
+        }
+    }
+    return ret;
+}
+
+template<typename R, typename F, typename... Args>
+OBFY_NOINLINE typename std::enable_if<std::is_void<R>::value, void>::type
+obfy_call_impl(F f, Args&&... args) {
+    const uintptr_t salt = detail::mix64(OBFY_LOCAL_KEY() ^ detail::runtime_tweak_seed());
+    obf_addr<F> oa(f, salt);
+    volatile uint32_t s = static_cast<uint32_t>(salt);
+    const uint32_t fire = s % OBFY_CALL_STEPS;
+    for (uint32_t i = 0; i < OBFY_CALL_STEPS; ++i) {
+        s = detail::lcg(s) ^ static_cast<uint32_t>(i * 2654435761u);
+        if (i == fire) {
+            F g = oa.get();
+            g(std::forward<Args>(args)...);
+        } else {
+            s ^= (s >> 13);
+        }
+    }
+}
+
+#define OBFY_CALL_RET(R, f, ...) (::obfy::obfy_call_impl<R>(f, __VA_ARGS__))
+#define OBFY_CALL(f, ...) (::obfy::obfy_call_impl<void>(f, __VA_ARGS__))
+
+#else  // OBFY_ENABLE_FSM_CALL
+
+#define OBFY_CALL_RET(R, f, ...) (f(__VA_ARGS__))
+#define OBFY_CALL(f, ...) (f(__VA_ARGS__))
+
+#endif // OBFY_ENABLE_FSM_CALL
+
+} // namespace obfy
+
+#endif // __OBFY_CALL_HPP__

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -3,7 +3,8 @@
 #include <boost/test/auto_unit_test.hpp>
 #define BOOST_AUTO_TEST_OBFY_CASE BOOST_AUTO_TEST_CASE
 
-#include <obfy/obfy.hpp>
+#define OBFY_ENABLE_FSM_CALL
+#include <obfy/obfy_call.hpp>
 #include <stdint.h>
 #include <limits>
 #include <memory>
@@ -179,5 +180,16 @@ BOOST_AUTO_TEST_OBFY_CASE(extra_operations_roundtrip)
     test_type<obfy::extra_affine, uint16_t>(static_cast<uint16_t>(0xBEEF));
     test_type<obfy::extra_affine, uint32_t>(0xDEADBEEFu);
     test_type<obfy::extra_affine, uint64_t>(0x0123456789ABCDEFULL);
+}
+
+OBFY_NOINLINE static int add_obf(int a, int b) { return a + b; }
+OBFY_NOINLINE static void inc_obf(int& x) { ++x; }
+
+BOOST_AUTO_TEST_OBFY_CASE(obfuscated_call)
+{
+    BOOST_CHECK_EQUAL(OBFY_CALL_RET(int, add_obf, 40, 2), 42);
+    int v = 1;
+    OBFY_CALL(inc_obf, v);
+    BOOST_CHECK_EQUAL(v, 2);
 }
 


### PR DESCRIPTION
## Summary
- add configurable obfuscated call macros with XOR address hiding and pseudo-random loop
- split obfuscated call helpers into dedicated header and include from core header
- document new call obfuscation option
- exercise obfuscated calls in unit tests
- move macros and fallbacks into standalone header and include it directly where needed

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y libboost-test-dev`
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bd0efc9644832ca9d13d69b00c6e57