### PR TITLE
chore: prepare 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.0] - 2024-05-06
+## [1.0.0] - 2025-09-07
 - Initial release of the forked project.
-- Added new features not available in the original repository.
+- Added obfuscated function call macros `OBFY_CALL` and `OBFY_CALL_RET`.
+- Provided compile-time string obfuscation via `OBFY_STR` and related helpers.
+- Introduced numeric and control-flow obfuscation wrappers.
 - Renamed multiple macros for clarity and consistency.
-- Numerous improvements and adjustments across the codebase.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(obfy LANGUAGES CXX)
+project(obfy VERSION 1.0.0 LANGUAGES CXX)
 
 add_library(obfy INTERFACE)
 target_include_directories(obfy INTERFACE

--- a/MACROS.md
+++ b/MACROS.md
@@ -1,0 +1,54 @@
+# Obfuscation Macros
+
+This document summarizes the public macros provided by **obfy** and shows short usage examples.
+
+## String obfuscation
+
+- `OBFY_STR`, `OBFY_WSTR`
+- `OBFY_STR_ONCE`, `OBFY_WSTR_ONCE`
+
+```cpp
+const char* msg = OBFY_STR("secret");
+auto tmp = OBFY_STR_ONCE("one-shot");
+```
+
+## Function call obfuscation
+
+Requires including `obfy_call.hpp`. Define `OBFY_ENABLE_FSM_CALL` to enable the state-machine wrapper.
+
+- `OBFY_CALL`
+- `OBFY_CALL_RET`
+
+```cpp
+int r = OBFY_CALL_RET(int, add, 1, 2);
+OBFY_CALL(do_work);
+```
+
+## Numeric obfuscation
+
+- `OBFY_V`, `OBFY_N`
+- `OBFY_RATIO_D`, `OBFY_RATIO_F`
+- `OBFY_BIT_CAST`
+
+```cpp
+OBFY_V(x) = 42;
+int n = OBFY_N(10);
+double pi = OBFY_RATIO_D(314, 100);
+```
+
+## Control-flow obfuscation
+
+- `OBFY_BEGIN_CODE` / `OBFY_END_CODE`
+- `OBFY_IF` / `OBFY_ELSE` / `OBFY_ENDIF`
+- `OBFY_FOR` / `OBFY_ENDFOR`, `OBFY_WHILE` / `OBFY_ENDWHILE`
+- `OBFY_REPEAT` / `OBFY_AS_LONG_AS`
+- `OBFY_CASE` / `OBFY_WHEN` / `OBFY_DO` / `OBFY_DONE` / `OBFY_OR` / `OBFY_DEFAULT` / `OBFY_ENDCASE`
+- `OBFY_RETURN`, `OBFY_BREAK`, `OBFY_CONTINUE`
+
+```cpp
+OBFY_BEGIN_CODE
+    OBFY_IF(check())
+        OBFY_RETURN(42);
+    OBFY_ENDIF
+OBFY_END_CODE
+```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OBFY offers lightweight compile-time obfuscation for strings and numeric constan
 
 | Approach | Protects | Against | Cost |
 | --- | --- | --- | --- |
-| Lightweight obfuscation (`OBFY_STR`, wrappers) | Encodes literals at compile time, decodes on first use | Simple static searches, single-key XOR scans | Low — header-only, minimal runtime overhead |
+| Lightweight obfuscation (`OBFY_STR`, wrappers, `OBFY_CALL`) | Encodes literals at compile time, decodes on first use, hides call targets | Simple static searches, single-key XOR scans | Low — header-only, minimal runtime overhead |
 | Full protection (packers, virtualization, anti-tamper) | Entire binary with anti-debug and integrity checks | Skilled reverse engineers, automated tooling | High — external tools, performance and licensing cost |
 
 # Building
@@ -1225,6 +1225,15 @@ String literals can be protected with `OBFY_STR`. The characters are encoded at 
 
 ```cpp
 const char* hello = OBFY_STR("hello world");
+```
+
+Function calls can be wrapped with macros from `include/obfy/obfy_call.hpp`. Defining
+`OBFY_ENABLE_FSM_CALL` inserts a tiny state machine before invoking the target, making
+control-flow tracing harder.
+
+```cpp
+int result = OBFY_CALL_RET(int, add, 2, 3);
+OBFY_CALL(print_message, "hi");
 ```
 
 For floating point constants you can assemble them from integers with `OBFY_RATIO_D` or `OBFY_RATIO_F`, e.g. `double pi = OBFY_RATIO_D(314, 100);`. These macros divide the obfuscated numerator and denominator at runtime. If an exact IEEE-754 bit pattern is required, store the bits as an integer and recover the value via `OBFY_BIT_CAST`.


### PR DESCRIPTION
## Summary
- set project version to 1.0.0 in CMake
- document initial 1.0.0 release and new call obfuscation macros
- add macro reference guide

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68bd19628978832ca9cd90fc8e50dbfd