### PR TITLE
feat: add obfuscated byte block macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ All notable changes to this project will be documented in this file.
 - Provided compile-time string obfuscation via `OBFY_STR` and related helpers.
 - Introduced numeric and control-flow obfuscation wrappers.
 - Renamed multiple macros for clarity and consistency.
+- Added obfuscated byte block macros `OBFY_BYTES` and `OBFY_BYTES_ONCE`.
 

--- a/MACROS.md
+++ b/MACROS.md
@@ -14,6 +14,18 @@ auto tmp = OBFY_STR_ONCE("one-shot");
 auto wtmp = OBFY_WSTR_ONCE(L"w-one-shot");
 ```
 
+## Byte block obfuscation
+
+- `OBFY_BYTES`
+- `OBFY_BYTES_ONCE`
+
+Requires including `obfy_bytes.hpp`.
+
+```cpp
+const unsigned char* key = OBFY_BYTES("\x01\x02\x03\x04");
+auto tmp_block = OBFY_BYTES_ONCE("\xAA\xBB");
+```
+
 ## Function call obfuscation
 
 Requires including `obfy_call.hpp`. Define `OBFY_ENABLE_FSM_CALL` to enable the state-machine wrapper.

--- a/include/obfy/obfy_bytes.hpp
+++ b/include/obfy/obfy_bytes.hpp
@@ -1,0 +1,68 @@
+#ifndef __OBFY_BYTES_HPP__
+#define __OBFY_BYTES_HPP__
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <array>
+
+#include <obfy/obfy.hpp>
+
+namespace obfy {
+namespace detail {
+
+    template<unsigned char K1, unsigned char K2, unsigned char K3, typename Seq>
+    struct obf_bytes_impl;
+
+    template<unsigned char K1, unsigned char K2, unsigned char K3, std::size_t... I>
+    struct obf_bytes_impl<K1, K2, K3, index_sequence<I...>> {
+        unsigned char data[sizeof...(I)];
+        mutable std::once_flag once_;
+        template<std::size_t N>
+        constexpr obf_bytes_impl(const char (&s)[N])
+            : data{ encode(reinterpret_cast<const unsigned char*>(s)[I], I)... } {}
+        const unsigned char* decrypt() {
+            std::call_once(once_, [&]{
+                for (std::size_t i = 0; i < sizeof...(I); ++i)
+                    data[i] = decode(data[i], i);
+            });
+            return data;
+        }
+        struct tmp_block {
+            std::array<unsigned char, sizeof...(I)> bytes;
+            ~tmp_block() { for (std::size_t i = 0; i < bytes.size(); ++i) bytes[i] = 0; }
+            const unsigned char* data() const { return bytes.data(); }
+            std::size_t size() const { return bytes.size(); }
+        };
+        tmp_block decrypt_once() const {
+            tmp_block tmp;
+            for (std::size_t i = 0; i < sizeof...(I); ++i)
+                tmp.bytes[i] = decode(data[i], i);
+            return tmp;
+        }
+        static constexpr unsigned char encode(unsigned char c, std::size_t i) {
+            return static_cast<unsigned char>(((c ^ K1) + K2) ^ static_cast<unsigned char>(K3 + static_cast<unsigned char>(i)));
+        }
+        static constexpr unsigned char decode(unsigned char c, std::size_t i) {
+            return static_cast<unsigned char>(((c ^ static_cast<unsigned char>(K3 + static_cast<unsigned char>(i))) - K2) ^ K1);
+        }
+    };
+
+} // namespace detail
+} // namespace obfy
+
+#ifndef OBFY_TU_SALT
+#  define OBFY_TU_SALT 0ull
+#endif
+
+#define OBFY_DEF_BYTES(b) \
+    ::obfy::detail::obf_bytes_impl< \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 0) & 0xFF)), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 8) & 0xFF)), \
+        static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 16) & 0xFF)), \
+        ::obfy::detail::make_index_sequence<sizeof(b) - 1>>
+
+#define OBFY_BYTES(b) ([](){ static OBFY_DEF_BYTES(b) _obfy_bytes{ b }; return _obfy_bytes.decrypt(); }())
+#define OBFY_BYTES_ONCE(b) ([](){ OBFY_DEF_BYTES(b) _obfy_bytes{ b }; return _obfy_bytes.decrypt_once(); }())
+
+#endif // __OBFY_BYTES_HPP__

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -9,6 +9,7 @@
 
 #define OBFY_ENABLE_FSM_CALL
 #include <obfy/obfy_call.hpp>
+#include <obfy/obfy_bytes.hpp>
 #include <stdint.h>
 #include <limits>
 #include <memory>
@@ -132,6 +133,18 @@ BOOST_AUTO_TEST_OBFY_CASE(string_literal)
     BOOST_CHECK_EQUAL(std::string(OBFY_STR("")), "");
     BOOST_CHECK_EQUAL(std::string(OBFY_STR_ONCE("test once")), "test once");
     BOOST_CHECK(std::wstring(OBFY_WSTR(L"wide")) == L"wide");
+}
+
+BOOST_AUTO_TEST_OBFY_CASE(byte_block)
+{
+    const unsigned char* data = OBFY_BYTES("\x01\x02\x03\x04");
+    BOOST_CHECK_EQUAL(data[0], 0x01);
+    BOOST_CHECK_EQUAL(data[3], 0x04);
+
+    auto once = OBFY_BYTES_ONCE("\x05\x06");
+    BOOST_CHECK_EQUAL(once.size(), 2u);
+    BOOST_CHECK_EQUAL(once.data()[0], 0x05);
+    BOOST_CHECK_EQUAL(once.data()[1], 0x06);
 }
 
 BOOST_AUTO_TEST_OBFY_CASE(float_variable_wrapper)


### PR DESCRIPTION
## Summary
- add support for compile-time obfuscated byte blocks
- document byte block macros
- record new byte obfuscation in changelog

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bd1e3123c8832c86c36bb72a60dc54