### PR TITLE
Clarify *_ONCE lifetime and tighten obfuscation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+- document lifetime of `*_ONCE` macros
+- remove redundant `OBFY_TU_SALT` defaults
+- add character-width check for obfuscated strings
+- drop `constexpr` from `obf_string_impl` constructor
+
 ## [1.0.0] - 2025-09-07
 - Initial release of the forked project.
 - Added obfuscated function call macros `OBFY_CALL` and `OBFY_CALL_RET`.

--- a/MACROS.md
+++ b/MACROS.md
@@ -14,6 +14,8 @@ auto tmp = OBFY_STR_ONCE("one-shot");
 auto wtmp = OBFY_WSTR_ONCE(L"w-one-shot");
 ```
 
+`*_ONCE` macros return a temporary that zeroes its storage on destruction. Pointers from `c_str()` remain valid only within the full expression; copy the string if a longer lifetime is required.
+
 ## Byte block obfuscation
 
 - `OBFY_BYTES`
@@ -25,6 +27,8 @@ Requires including `obfy_bytes.hpp`.
 const unsigned char* key = OBFY_BYTES("\x01\x02\x03\x04");
 auto tmp_block = OBFY_BYTES_ONCE("\xAA\xBB");
 ```
+
+`OBFY_BYTES_ONCE` behaves similarly, returning a temporary block that clears its contents when destroyed.
 
 ## Function call obfuscation
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ of protection.
 - **TU-salt controls**: `OBFY_FILE_FOR_HASH`, `OBFY_TU_SALT`;
 - **build system cleanup** (CMake options; tests/examples toggles).
 
+> Define a non-zero `OBFY_TU_SALT` globally (e.g. via `-DOBFY_TU_SALT=0x1234`) to further diversify keys across translation units.
+
 ## Quick Start
 
 Add the library to your CMake project:

--- a/include/obfy/obfy_bytes.hpp
+++ b/include/obfy/obfy_bytes.hpp
@@ -62,10 +62,6 @@ namespace detail {
 } // namespace detail
 } // namespace obfy
 
-#ifndef OBFY_TU_SALT
-#  define OBFY_TU_SALT 0ull // define to a non-zero per translation unit salt
-#endif
-
 #define OBFY_DEF_BYTES(b) /* b must be a string literal or static array */ \
     ::obfy::detail::obf_bytes_impl< \
         static_cast<unsigned char>(::obfy::MetaRandom<__COUNTER__, 256>::value ^ static_cast<unsigned char>((OBFY_TU_SALT >> 0) & 0xFF)), \
@@ -74,6 +70,7 @@ namespace detail {
         ::obfy::detail::make_index_sequence<sizeof(b) - 1>>
 
 #define OBFY_BYTES(b) ([](){ static OBFY_DEF_BYTES(b) _obfy_bytes{ b }; return _obfy_bytes.decrypt(); }())
+// `OBFY_BYTES_ONCE` returns a temporary wiping its contents on destruction.
 #define OBFY_BYTES_ONCE(b) ([](){ OBFY_DEF_BYTES(b) _obfy_bytes{ b }; return _obfy_bytes.decrypt_once(); }())
 
 #endif // __OBFY_BYTES_HPP__


### PR DESCRIPTION
## Summary
- Document limited lifetime for `*_ONCE` macros and temporary wiping behavior
- Ensure obfuscated strings respect character width
- Remove redundant `OBFY_TU_SALT` defaults and mention global usage in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bd8477e270832c81a6610a30354a44