### PR TITLE
feat(str): enforce matching literal width

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,14 @@ if(OBFY_BUILD_TESTS)
     target_link_libraries(obfy_tests_debug PRIVATE obfy Boost::unit_test_framework)
     target_compile_definitions(obfy_tests_debug PRIVATE UNIT_TESTS OBFY_DEBUG)
     add_test(NAME obfy_tests_debug COMMAND obfy_tests_debug)
+
+    add_test(NAME invalid_str_literal
+        COMMAND ${CMAKE_CXX_COMPILER} -std=c++11 -I${CMAKE_CURRENT_SOURCE_DIR}/include -c ${CMAKE_CURRENT_SOURCE_DIR}/tests/invalid_str_char.cpp -o invalid_str_char.o)
+    set_tests_properties(invalid_str_literal PROPERTIES WILL_FAIL TRUE)
+
+    add_test(NAME invalid_wstr_literal
+        COMMAND ${CMAKE_CXX_COMPILER} -std=c++11 -I${CMAKE_CURRENT_SOURCE_DIR}/include -c ${CMAKE_CURRENT_SOURCE_DIR}/tests/invalid_wstr_char.cpp -o invalid_wstr_char.o)
+    set_tests_properties(invalid_wstr_literal PROPERTIES WILL_FAIL TRUE)
 endif()
 
 install(TARGETS obfy)

--- a/MACROS.md
+++ b/MACROS.md
@@ -14,6 +14,10 @@ auto tmp = OBFY_STR_ONCE("one-shot");
 auto wtmp = OBFY_WSTR_ONCE(L"w-one-shot");
 ```
 
+These macros accept only string literals whose character type matches the macro.
+Using a wide literal with `OBFY_STR` or a narrow literal with `OBFY_WSTR`
+results in a compilation error.
+
 `*_ONCE` macros return a temporary that zeroes its storage on destruction. Pointers from `c_str()` remain valid only within the full expression; copy the string if a longer lifetime is required.
 
 ## Byte block obfuscation

--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -19,9 +19,11 @@ namespace detail {
     struct obf_string_impl<Char, K1, K2, K3, index_sequence<I...>> {
         alignas(Char) unsigned char data[sizeof...(I) + sizeof(Char)];
         mutable std::once_flag once_;
-        template<std::size_t N>
-        obf_string_impl(const Char (&s)[N])
-            : data{ encode(reinterpret_cast<const unsigned char*>(s)[I], I)... } {}
+        template<typename SChar, std::size_t N>
+        obf_string_impl(const SChar (&s)[N])
+            : data{ encode(reinterpret_cast<const unsigned char*>(s)[I], I)... } {
+            static_assert(sizeof(s[0]) == sizeof(Char), "string literal has wrong character width");
+        }
         static_assert((sizeof...(I) % sizeof(Char)) == 0, "byte count must be multiple of Char");
         const Char* decrypt() {
             std::call_once(once_, [&]{

--- a/tests/invalid_str_char.cpp
+++ b/tests/invalid_str_char.cpp
@@ -1,0 +1,6 @@
+#include <obfy/obfy_str.hpp>
+
+void invalid_str_char() {
+    (void)OBFY_STR(L"wide");
+}
+

--- a/tests/invalid_wstr_char.cpp
+++ b/tests/invalid_wstr_char.cpp
@@ -1,0 +1,6 @@
+#include <obfy/obfy_str.hpp>
+
+void invalid_wstr_char() {
+    (void)OBFY_WSTR("narrow");
+}
+


### PR DESCRIPTION
## Summary
- ensure obfuscation macros reject string literals with mismatched character width
- cover incorrect literal widths with compile-fail tests
- document that macros require matching literal types

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68be627eb5d8832cb57673c1c070b921