### PR TITLE
refactor(include): inline header utilities

### DIFF
--- a/include/obfy/obfy_bytes.hpp
+++ b/include/obfy/obfy_bytes.hpp
@@ -2,7 +2,6 @@
 #define __OBFY_BYTES_HPP__
 
 #include <cstddef>
-#include <cstdint>
 #include <mutex>
 #include <array>
 
@@ -25,11 +24,11 @@ namespace detail {
             : data{ encode(static_cast<unsigned char>(s[I]), I)... } {}
 
         static constexpr std::size_t size_static() { return sizeof...(I); }
-        std::size_t size() const { return sizeof...(I); }
+        constexpr std::size_t size() const { return sizeof...(I); }
 
         // decrypt() decodes bytes once and keeps them in place.
         // For sensitive data prefer decrypt_once().
-        const unsigned char* decrypt() {
+        inline const unsigned char* decrypt() {
             std::call_once(once_, [&]{
                 for (std::size_t i = 0; i < sizeof...(I); ++i)
                     data[i] = decode(data[i], i);
@@ -38,14 +37,14 @@ namespace detail {
         }
         struct tmp_block {
             std::array<unsigned char, sizeof...(I)> bytes{};
-            ~tmp_block() {
+            inline ~tmp_block() {
                 volatile unsigned char* p = bytes.data();
                 for (std::size_t i = 0; i < bytes.size(); ++i) p[i] = 0;
             }
-            const unsigned char* data() const { return bytes.data(); }
-            std::size_t size() const { return bytes.size(); }
+            inline const unsigned char* data() const { return bytes.data(); }
+            inline std::size_t size() const { return bytes.size(); }
         };
-        tmp_block decrypt_once() const {
+        inline tmp_block decrypt_once() const {
             tmp_block tmp;
             for (std::size_t i = 0; i < sizeof...(I); ++i)
                 tmp.bytes[i] = decode(data[i], i);

--- a/include/obfy/obfy_str.hpp
+++ b/include/obfy/obfy_str.hpp
@@ -2,7 +2,6 @@
 #define __OBFY_STR_HPP__
 
 #include <cstddef>
-#include <cstdint>
 #include <mutex>
 #include <string>
 
@@ -25,7 +24,7 @@ namespace detail {
             static_assert(sizeof(s[0]) == sizeof(Char), "string literal has wrong character width");
         }
         static_assert((sizeof...(I) % sizeof(Char)) == 0, "byte count must be multiple of Char");
-        const Char* decrypt() {
+        inline const Char* decrypt() {
             std::call_once(once_, [&]{
                 for (std::size_t i = 0; i < sizeof...(I); ++i)
                     data[i] = decode(data[i], i);
@@ -34,11 +33,11 @@ namespace detail {
         }
         struct tmp_string {
             std::basic_string<Char> str;
-            ~tmp_string() { for (std::size_t i = 0; i < str.size(); ++i) str[i] = Char(); }
-            operator const std::basic_string<Char>&() const { return str; }
-            const Char* c_str() const { return str.c_str(); } // valid while tmp_string lives
+            inline ~tmp_string() { for (std::size_t i = 0; i < str.size(); ++i) str[i] = Char(); }
+            inline operator const std::basic_string<Char>&() const { return str; }
+            inline const Char* c_str() const { return str.c_str(); } // valid while tmp_string lives
         };
-        tmp_string decrypt_once() const {
+        inline tmp_string decrypt_once() const {
             tmp_string tmp;
             tmp.str.resize(sizeof...(I) / sizeof(Char));
             unsigned char* raw = reinterpret_cast<unsigned char*>(&tmp.str[0]);


### PR DESCRIPTION
## Summary
- remove unused `<cstdint>` includes from byte and string helpers
- inline and `constexpr` helper functions to avoid ODR issues
- confirm existing include guards in meta utilities

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be74a4f984832cbf7a25498a1eccf6