### PR TITLE
docs: summarize recent changes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,7 @@ All notable changes to this project will be documented in this file.
 - Introduced numeric and control-flow obfuscation wrappers.
 - Renamed multiple macros for clarity and consistency.
 - Added obfuscated byte block macros `OBFY_BYTES` and `OBFY_BYTES_ONCE`.
+- Added: `OBFY_STR/OBFY_WSTR`, `OBFY_BYTES/OBFY_BYTES_ONCE`
+- Improved: TU-salt, runtime tweak
+- Fixed: `refholder::operator==` constraints
 


### PR DESCRIPTION
## Summary
- document new string and byte macros, runtime tweaks, and refholder fix under v1.0.0 release

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR unit_test_framework))*

------
https://chatgpt.com/codex/tasks/task_e_68be78a3a3dc832ca488e69a72f838a3