### PR TITLE
test: enhance byte_block coverage

### DIFF
--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -159,14 +159,31 @@ BOOST_AUTO_TEST_OBFY_CASE(string_literal)
 
 BOOST_AUTO_TEST_OBFY_CASE(byte_block)
 {
-    const unsigned char* data = OBFY_BYTES("\x01\x02\x03\x04");
-    BOOST_CHECK_EQUAL(data[0], 0x01);
-    BOOST_CHECK_EQUAL(data[3], 0x04);
+    OBFY_DEF_BYTES("\x01\x02\x03\x04") block4{"\x01\x02\x03\x04"};
+    BOOST_CHECK_EQUAL(decltype(block4)::size_static(), 4u);
+    BOOST_CHECK_EQUAL(block4.size(), 4u);
+    const unsigned char* data4 = OBFY_BYTES("\x01\x02\x03\x04");
+    BOOST_CHECK_EQUAL(data4[0], 0x01);
+    BOOST_CHECK_EQUAL(data4[3], 0x04);
 
-    auto once = OBFY_BYTES_ONCE("\x05\x06");
-    BOOST_CHECK_EQUAL(once.size(), 2u);
-    BOOST_CHECK_EQUAL(once.data()[0], 0x05);
-    BOOST_CHECK_EQUAL(once.data()[1], 0x06);
+    OBFY_DEF_BYTES("\x07") block1{"\x07"};
+    BOOST_CHECK_EQUAL(decltype(block1)::size_static(), 1u);
+    BOOST_CHECK_EQUAL(block1.size(), 1u);
+    const unsigned char* data1 = OBFY_BYTES("\x07");
+    BOOST_CHECK_EQUAL(data1[0], 0x07);
+
+    const unsigned char* wiped = nullptr;
+    {
+        auto once = OBFY_BYTES_ONCE("\x05\x06\x07");
+        BOOST_CHECK_EQUAL(once.size(), 3u);
+        wiped = once.data();
+        BOOST_CHECK_EQUAL(wiped[0], 0x05);
+        BOOST_CHECK_EQUAL(wiped[1], 0x06);
+        BOOST_CHECK_EQUAL(wiped[2], 0x07);
+    }
+    BOOST_CHECK_EQUAL(wiped[0], 0u);
+    BOOST_CHECK_EQUAL(wiped[1], 0u);
+    BOOST_CHECK_EQUAL(wiped[2], 0u);
 }
 
 BOOST_AUTO_TEST_OBFY_CASE(float_variable_wrapper)

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -254,6 +254,8 @@ BOOST_AUTO_TEST_OBFY_CASE(string_obfuscation_binary_check)
     // determine project root from this file path
     std::string file_path(__FILE__);
     std::size_t pos = file_path.rfind("/tests/");
+    if(pos == std::string::npos)
+        pos = file_path.rfind("\\tests\\");
     BOOST_REQUIRE(pos != std::string::npos);
     std::string root = file_path.substr(0, pos);
     std::string include_dir = root + "/include";

--- a/tests/obfy_tests.cpp
+++ b/tests/obfy_tests.cpp
@@ -263,8 +263,8 @@ BOOST_AUTO_TEST_OBFY_CASE(string_obfuscation_binary_check)
     const char* narrow = "super_secret_narrow_literal";
     const wchar_t* wide = L"super_secret_wide_literal";
 
-    const std::string src = std::string("/tmp/obfy_tmp_prog.cpp");
-    const std::string bin = std::string("/tmp/obfy_tmp_prog.bin");
+    const std::string src = root + "/obfy_tmp_prog.cpp";
+    const std::string bin = root + "/obfy_tmp_prog.bin";
 
     {
         std::ofstream ofs(src.c_str());


### PR DESCRIPTION
## Summary
- verify `OBFY_BYTES` compile-time and runtime sizes
- ensure `OBFY_BYTES_ONCE` buffer wipes after scope
- exercise byte block macros with varying lengths

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68be7d1bee50832c8ab408e1db239cbe