### PR TITLE
feat(examples): add string, bytes, and license demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,23 +8,32 @@ target_include_directories(obfy INTERFACE
 
 target_compile_features(obfy INTERFACE cxx_std_11)
 
-option(OBFY_BUILD_EXAMPLE "Build example program" ON)
+option(OBFY_BUILD_EXAMPLES "Build example programs" ON)
 option(OBFY_BUILD_TESTS "Build unit tests" ON)
 
-if(OBFY_BUILD_EXAMPLE)
-    add_executable(example example/main.cpp)
-    target_link_libraries(example PRIVATE obfy)
+if(OBFY_BUILD_EXAMPLES)
+    add_executable(obfy_example examples/obf.cpp)
+    target_link_libraries(obfy_example PRIVATE obfy)
+
+    add_executable(obfy_example_string examples/string.cpp)
+    target_link_libraries(obfy_example_string PRIVATE obfy)
+
+    add_executable(obfy_example_bytes examples/bytes.cpp)
+    target_link_libraries(obfy_example_bytes PRIVATE obfy)
+
+    add_executable(obfy_example_license examples/license.cpp)
+    target_link_libraries(obfy_example_license PRIVATE obfy)
 endif()
 
 if(OBFY_BUILD_TESTS)
     enable_testing()
     find_package(Boost REQUIRED COMPONENTS unit_test_framework)
-    add_executable(obfy_tests tests/obfy_tests.cpp tests/license_tests.cpp example/main.cpp)
+    add_executable(obfy_tests tests/obfy_tests.cpp tests/license_tests.cpp examples/obf.cpp)
     target_link_libraries(obfy_tests PRIVATE obfy Boost::unit_test_framework)
     target_compile_definitions(obfy_tests PRIVATE UNIT_TESTS)
     add_test(NAME obfy_tests COMMAND obfy_tests)
 
-    add_executable(obfy_tests_debug tests/obfy_tests.cpp tests/license_tests.cpp example/main.cpp)
+    add_executable(obfy_tests_debug tests/obfy_tests.cpp tests/license_tests.cpp examples/obf.cpp)
     target_link_libraries(obfy_tests_debug PRIVATE obfy Boost::unit_test_framework)
     target_compile_definitions(obfy_tests_debug PRIVATE UNIT_TESTS OBFY_DEBUG)
     add_test(NAME obfy_tests_debug COMMAND obfy_tests_debug)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OBFY
 
+[![Build Status](https://github.com/NewYaroslav/obfy/actions/workflows/build.yml/badge.svg)](https://github.com/NewYaroslav/obfy/actions/workflows/build.yml)
+
 OBFY is a *header-only* C++ library for code obfuscation. It offers a set of macros and
 lightweight wrappers that expand straightforward constructs into randomized sequences of
 operations, increasing the effort required for reverse engineering and bypassing basic
 license checks. The library targets developers who need a minimal, dependency-free layer
 of protection.
-
-[![Build Status](https://github.com/NewYaroslav/obfy/actions/workflows/build.yml/badge.svg)](https://github.com/NewYaroslav/obfy/actions/workflows/build.yml)
 
 **This fork differs from the original ADVobfuscator by:**
 - **renaming/isolating macros** to avoid collisions (e.g., with Eigen);
@@ -74,6 +74,13 @@ xxd -p -l2 /dev/urandom
 od -An -tx2 -N2 /dev/urandom
 ```
 
+Per-file salts on the command line:
+
+```bash
+g++ -Iinclude -DOBFY_TU_SALT=0x1111 -c foo.cpp
+g++ -Iinclude -DOBFY_TU_SALT=0x2222 -c bar.cpp
+```
+
 ## Obfuscation vs Protection
 
 OBFY offers lightweight compile-time obfuscation for strings and numeric constants. It complicates casual static inspection but is **not** a full protection suite.
@@ -93,10 +100,10 @@ cmake --build build
 ```
 
 Options (defaults in **bold**):
-- `-DOBFY_BUILD_EXAMPLE=**ON**|OFF`
+- `-DOBFY_BUILD_EXAMPLES=**ON**|OFF`
 - `-DOBFY_BUILD_TESTS=**ON**|OFF`
 
-The example executable is placed under `build/example/`. To install the
+Example executables are placed under `build/`. To install the
 headers system-wide, use:
 
 ```

--- a/examples/bytes.cpp
+++ b/examples/bytes.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <iomanip>
+#include <obfy/obfy_bytes.hpp>
+
+int main() {
+    const unsigned char* data = OBFY_BYTES("\x01\x02\x03");
+    std::cout << std::hex << std::setfill('0');
+    for (std::size_t i = 0; i < 3; ++i)
+        std::cout << std::setw(2) << static_cast<int>(data[i]) << ' ';
+    std::cout << std::dec << std::endl;
+
+    auto once = OBFY_BYTES_ONCE("\x05\x06\x07");
+    for (std::size_t i = 0; i < once.size(); ++i)
+        std::cout << std::setw(2) << static_cast<int>(once.data()[i]) << ' ';
+    std::cout << std::dec << std::endl;
+}

--- a/examples/license.cpp
+++ b/examples/license.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <string>
+#include <cstring>
+#include <obfy/obfy.hpp>
+
+static const char letters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+bool check_license1(const char* user, const char* users_license) {
+    OBFY_BEGIN_CODE
+    std::string license;
+    size_t ll = strlen(users_license);
+    size_t l = strlen(user), lic_ctr = OBFY_N(0);
+
+    size_t add = OBFY_N(0), i = OBFY_N(0);
+
+    OBFY_FOR(OBFY_V(i) = OBFY_N(0), OBFY_V(i) < OBFY_V(ll), OBFY_V(i)++)
+        OBFY_IF(OBFY_V(users_license[i]) != OBFY_N(45))
+            license += users_license[i];
+        OBFY_ENDIF
+    OBFY_ENDFOR
+
+    OBFY_WHILE(OBFY_V(lic_ctr) < license.length())
+        size_t i = lic_ctr;
+        OBFY_V(i) %= l;
+        int current = 0;
+        OBFY_WHILE(OBFY_V(i) < OBFY_V(l))
+            OBFY_V(current) += user[OBFY_V(i)];
+            OBFY_V(i)++;
+        OBFY_ENDWHILE
+        OBFY_V(current) += OBFY_V(add);
+        ++OBFY_V(add);
+
+        OBFY_IF((license[lic_ctr] != letters[current % sizeof letters]))
+            OBFY_RETURN(false);
+        OBFY_ENDIF
+
+        lic_ctr++;
+    OBFY_ENDWHILE
+
+    OBFY_RETURN(true);
+
+    OBFY_END_CODE
+}
+
+std::string generate_license(const char* user) {
+    if(!user) return "";
+    static const char letters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    char result[17] = {0};
+    size_t l = strlen(user), lic_ctr = 0;
+    int add = 0;
+    while(lic_ctr < 16) {
+        size_t i = lic_ctr;
+        i %= l;
+        int current = 0;
+        while(i < l) {
+            current += user[i];
+            i++;
+        }
+        current += add;
+        add++;
+
+        result[lic_ctr] = letters[current % sizeof letters];
+        lic_ctr++;
+    }
+
+    return std::string(result);
+}
+
+#ifndef UNIT_TESTS
+int main() {
+    const char* user = "obfy";
+    std::string license = generate_license(user);
+    std::cout << "License: " << license << std::endl;
+    std::cout << std::boolalpha << "Valid: "
+              << check_license1(user, license.c_str()) << std::endl;
+}
+#endif

--- a/examples/obf.cpp
+++ b/examples/obf.cpp
@@ -369,8 +369,5 @@ int main()
     int64_t bigNumber;
     OBFY_V(bigNumber) = OBFY_N(1537232811123);
     std::cout << "1537232811123:" << bigNumber << std::endl;
-    std::cout << OBFY_STR("hello obfy") << std::endl;
-    std::cout << OBFY_STR_ONCE("temp secret").c_str() << std::endl;
-    std::wcout << OBFY_WSTR(L"wide obfy") << std::endl;
 }
 #endif

--- a/examples/string.cpp
+++ b/examples/string.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include <obfy/obfy.hpp>
+
+int main() {
+    std::cout << OBFY_STR("hello obfy") << std::endl;
+    std::cout << OBFY_STR_ONCE("temp secret").c_str() << std::endl;
+    std::wcout << OBFY_WSTR(L"wide obfy") << std::endl;
+}


### PR DESCRIPTION
## Summary
- split monolithic example into string, bytes, and license programs
- make examples optional via CMake and adjust tests
- document per-file `OBFY_TU_SALT` usage and fetch methods
- rename main example source to `examples/obf.cpp` and update references

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68beecfa1ac0832cb5f7dc1255f02eac