### PR TITLE
Add CMake package config and vcpkg install test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,18 @@ jobs:
         run: cmake --build build --config Release
       - name: Test
         run: ctest --test-dir build -C Release --output-on-failure
+  Tests-Linux-vcpkg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cmake and vcpkg
+        run: |
+          sudo apt-get update && sudo apt-get install -y cmake
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+      - name: Build and Run Tests with vcpkg
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+          VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/vcpkg-port
+        run: |
+          CXX_STANDARD=17 ./scripts/run_tests.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ target_include_directories(obfy INTERFACE
 
 target_compile_features(obfy INTERFACE cxx_std_11)
 
+include(CMakePackageConfigHelpers)
+
 option(OBFY_BUILD_EXAMPLES "Build example programs" ON)
 option(OBFY_BUILD_TESTS "Build unit tests" ON)
 
@@ -47,5 +49,29 @@ if(OBFY_BUILD_TESTS)
     set_tests_properties(invalid_wstr_literal PROPERTIES WILL_FAIL TRUE)
 endif()
 
-install(TARGETS obfy)
+install(TARGETS obfy EXPORT obfyTargets)
 install(DIRECTORY include/ DESTINATION include)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/obfyConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/obfyConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/obfyConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/obfy
+)
+
+install(EXPORT obfyTargets
+    FILE obfyTargets.cmake
+    NAMESPACE obfy::
+    DESTINATION lib/cmake/obfy
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/obfyConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/obfyConfigVersion.cmake"
+    DESTINATION lib/cmake/obfy
+)

--- a/cmake/obfyConfig.cmake.in
+++ b/cmake/obfyConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/obfyTargets.cmake")
+

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -12,8 +12,9 @@ if [ -n "${VCPKG_ROOT:-}" ]; then
   if [ -n "${VCPKG_OVERLAY_PORTS:-}" ]; then
     INSTALL_OPTS+=("--overlay-ports=${VCPKG_OVERLAY_PORTS}")
   fi
-  "${VCPKG_ROOT}/vcpkg" install obfy "${INSTALL_OPTS[@]}"
-  CMAKE_FLAGS+=("-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+  TRIPLET=x64-linux-dynamic
+  "${VCPKG_ROOT}/vcpkg" install obfy boost-test --triplet ${TRIPLET} "${INSTALL_OPTS[@]}"
+  CMAKE_FLAGS+=("-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=${TRIPLET}")
 fi
 
 cmake -S . -B build "${CMAKE_FLAGS[@]}"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CMAKE_FLAGS=(-DCMAKE_BUILD_TYPE=Release)
+
+if [ -n "${CXX_STANDARD:-}" ]; then
+  CMAKE_FLAGS+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+fi
+
+if [ -n "${VCPKG_ROOT:-}" ]; then
+  INSTALL_OPTS=()
+  if [ -n "${VCPKG_OVERLAY_PORTS:-}" ]; then
+    INSTALL_OPTS+=("--overlay-ports=${VCPKG_OVERLAY_PORTS}")
+  fi
+  "${VCPKG_ROOT}/vcpkg" install obfy "${INSTALL_OPTS[@]}"
+  CMAKE_FLAGS+=("-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+fi
+
+cmake -S . -B build "${CMAKE_FLAGS[@]}"
+cmake --build build --config Release
+ctest --test-dir build -C Release --output-on-failure
+

--- a/vcpkg-port/obfy/portfile.cmake
+++ b/vcpkg-port/obfy/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_cmake_configure(
+    SOURCE_PATH ${CURRENT_PORT_DIR}/../..
+    OPTIONS -DOBFY_BUILD_EXAMPLES=OFF -DOBFY_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/obfy)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+

--- a/vcpkg-port/obfy/portfile.cmake
+++ b/vcpkg-port/obfy/portfile.cmake
@@ -7,5 +7,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/obfy)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/../../LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/vcpkg-port/obfy/vcpkg.json
+++ b/vcpkg-port/obfy/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "obfy",
+  "version-string": "1.0.0",
+  "description": "Compile-time string obfuscation library",
+  "homepage": "https://github.com/NewYaroslav/obfy",
+  "license": "MIT",
+  "dependencies": [
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
+}
+


### PR DESCRIPTION
## Summary
- install CMake package config to enable `find_package(obfy)`
- provide a vcpkg port and test script
- check vcpkg installation in CI on Linux

## Testing
- `CXX_STANDARD=17 ./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf1275bf9c832c8d1e35d381f28eec