### PR TITLE
docs: document find_package usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ of protection.
 
 ## Quick Start
 
+Using an installed package:
+
+```cmake
+find_package(obfy CONFIG REQUIRED)
+target_link_libraries(your-target PRIVATE obfy::obfy)
+```
+
 Add the library to your CMake project:
 
 ```cmake


### PR DESCRIPTION
## Summary
- document how to use a pre-installed obfy package with `find_package`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bf20a1f8f0832c88a3c42da3dde974