### PR TITLE
docs: document vcpkg installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ headers system-wide, use:
 cmake --install build --prefix /usr/local
 ```
 
+### vcpkg
+
+Install via [vcpkg](https://github.com/microsoft/vcpkg) using the provided
+overlay port:
+
+```bash
+vcpkg install obfy --overlay-ports=PATH/to/vcpkg-port
+```
+
+Then configure CMake with the vcpkg toolchain:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE=PATH/to/vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DVCPKG_OVERLAY_PORTS=PATH/to/vcpkg-port
+```
+
 ### Known limitations
 - Macros may evaluate arguments more than once (avoid side effects).
 - `OBFY_N` works only with integral/enum constant expressions.


### PR DESCRIPTION
## Summary
- document installing obfy through vcpkg overlay ports

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf2186d7a8832c8b19a40cdbbceec6