### PR TITLE
build: use GNUInstallDirs for install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(obfy VERSION 1.0.0 LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 add_library(obfy INTERFACE)
 target_include_directories(obfy INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -61,17 +63,17 @@ write_basic_package_version_file(
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/obfyConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/obfyConfig.cmake"
-    INSTALL_DESTINATION lib/cmake/obfy
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/obfy
 )
 
 install(EXPORT obfyTargets
     FILE obfyTargets.cmake
     NAMESPACE obfy::
-    DESTINATION lib/cmake/obfy
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/obfy
 )
 
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/obfyConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/obfyConfigVersion.cmake"
-    DESTINATION lib/cmake/obfy
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/obfy
 )

--- a/vcpkg-port/obfy/portfile.cmake
+++ b/vcpkg-port/obfy/portfile.cmake
@@ -5,6 +5,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_cmake_get_vars(cmake_vars_file)
+include(${cmake_vars_file})
+
+if(NOT VCPKG_TARGET_CMAKE_INSTALL_LIBDIR)
+    set(VCPKG_TARGET_CMAKE_INSTALL_LIBDIR lib)
+endif()
+
 vcpkg_cmake_config_fixup(CONFIG_PATH "${VCPKG_TARGET_CMAKE_INSTALL_LIBDIR}/cmake/obfy")
 
 vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/../../LICENSE")

--- a/vcpkg-port/obfy/portfile.cmake
+++ b/vcpkg-port/obfy/portfile.cmake
@@ -5,9 +5,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/obfy)
+vcpkg_cmake_config_fixup(CONFIG_PATH "${VCPKG_TARGET_CMAKE_INSTALL_LIBDIR}/cmake/obfy")
 
 vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/../../LICENSE")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/${VCPKG_TARGET_CMAKE_INSTALL_LIBDIR}")
 

--- a/vcpkg-port/obfy/vcpkg.json
+++ b/vcpkg-port/obfy/vcpkg.json
@@ -5,8 +5,9 @@
   "homepage": "https://github.com/NewYaroslav/obfy",
   "license": "MIT",
   "dependencies": [
-    "vcpkg-cmake",
-    "vcpkg-cmake-config"
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true },
+    { "name": "vcpkg-cmake-get-vars", "host": true }
   ]
 }
 


### PR DESCRIPTION
## Summary
- use GNUInstallDirs in build to respect system libdir
- update vcpkg port to use computed libdir

## Testing
- `cmake -S . -B build -DOBFY_BUILD_EXAMPLES=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bf22c6bcfc832ca14b8c70a35a8976